### PR TITLE
docs:스웨거 예시 추가

### DIFF
--- a/src/main/java/com/campus/campuscommunity/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/campus/campuscommunity/config/swagger/SwaggerConfig.java
@@ -7,14 +7,37 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
 
 @Configuration
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        // 개발 서버 설정
+        Server devServer = new Server();
+        devServer.setUrl("http://localhost:8080");
+        devServer.setDescription("개발 서버");
+
+        // 프로덕션 서버 설정 (나중에 배포 시 추가)
+        Server prodServer = new Server();
+        prodServer.setUrl("https://api.campuscommunity.com");
+        prodServer.setDescription("운영 서버");
+
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .description("JWT 토큰을 헤더에 입력하세요. 형식: Bearer {token}");
+
         return new OpenAPI()
                 .info(new Info()
                         .title("Campus Community API")
@@ -22,16 +45,31 @@ public class SwaggerConfig {
                         .version("1.0.0")
                         .contact(new Contact()
                                 .name("Campus Community Team")
-                                .email("support@campuscommunity.com"))
+                                .email("support@campuscommunity.com")
+                                .url("https://github.com/campuscommunity"))
                         .license(new License()
                                 .name("Apache 2.0")
-                                .url("http://www.apache.org/licenses/LICENSE-2.0.html")))
+                                .url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+                        .termsOfService("https://campuscommunity.com/terms"))
+                .servers(Arrays.asList(devServer, prodServer))
                 .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
                 .components(new Components()
-                        .addSecuritySchemes("Bearer Authentication", new SecurityScheme()
-                                .type(SecurityScheme.Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT")
-                                .description("JWT 토큰을 입력해주세요. 예: Bearer {token}")));
+                        .addSecuritySchemes("Bearer Authentication", securityScheme)
+                        .addExamples("회원가입 요청 예시",
+                                new Example()
+                                        .value("{\n" +
+                                                "  \"email\": \"user@university.ac.kr\",\n" +
+                                                "  \"password\": \"password123\",\n" +
+                                                "  \"name\": \"홍길동\",\n" +
+                                                "  \"department\": \"컴퓨터공학과\"\n" +
+                                                "}")
+                                        .summary("회원가입 요청 예시"))
+                        .addExamples("로그인 요청 예시",
+                                new Example()
+                                        .value("{\n" +
+                                                "  \"email\": \"user@university.ac.kr\",\n" +
+                                                "  \"password\": \"password123\"\n" +
+                                                "}")
+                                        .summary("로그인 요청 예시")));
     }
 }

--- a/src/main/java/com/campus/campuscommunity/domain/user/controller/UserController.java
+++ b/src/main/java/com/campus/campuscommunity/domain/user/controller/UserController.java
@@ -5,9 +5,15 @@ import com.campus.campuscommunity.common.response.ResponseCode;
 import com.campus.campuscommunity.domain.user.dto.UserRequestDto;
 import com.campus.campuscommunity.domain.user.dto.UserResponseDto;
 import com.campus.campuscommunity.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,6 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
+@Tag(name = "사용자 관리", description = "회원가입, 로그인, 사용자 정보 관리 API")
 public class UserController {
 
     private final UserService userService;
@@ -23,6 +30,25 @@ public class UserController {
      * 회원가입 API
      * POST /api/users/signup
      */
+    @Operation(
+            summary = "회원가입",
+            description = "새로운 사용자를 등록합니다. 이메일, 비밀번호, 이름, 학과 정보가 필요합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "회원가입 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponseDto.UserInfo.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (입력값 오류)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이메일 중복"
+            )
+    })
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<UserResponseDto.UserInfo>> signUp(
             @Valid @RequestBody UserRequestDto.SignUpRequest request) {
@@ -36,6 +62,25 @@ public class UserController {
      * 로그인 API
      * POST /api/users/login
      */
+    @Operation(
+            summary = "로그인",
+            description = "이메일과 비밀번호로 로그인합니다. 성공 시 JWT 토큰을 반환합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponseDto.LoginResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 비밀번호"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자 없음"
+            )
+    })
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<UserResponseDto.LoginResponse>> login(
             @Valid @RequestBody UserRequestDto.LoginRequest request) {
@@ -48,8 +93,24 @@ public class UserController {
      * 사용자 정보 조회 API
      * GET /api/users/me
      */
+    @Operation(
+            summary = "사용자 정보 조회",
+            description = "현재 로그인한 사용자의 정보를 조회합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponseDto.UserInfo.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자 없음"
+            )
+    })
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserResponseDto.UserInfo>> getMyInfo(
+            @Parameter(description = "사용자 이메일", example = "student@university.ac.kr", required = true)
             @RequestParam String email) {
 
         UserResponseDto.UserInfo userInfo = userService.getUserInfo(email);
@@ -60,8 +121,28 @@ public class UserController {
      * 사용자 정보 수정 API
      * PUT /api/users/me
      */
+    @Operation(
+            summary = "사용자 정보 수정",
+            description = "현재 로그인한 사용자의 이름과 학과 정보를 수정합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "정보 수정 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponseDto.UserInfo.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (입력값 오류)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자 없음"
+            )
+    })
     @PutMapping("/me")
     public ResponseEntity<ApiResponse<UserResponseDto.UserInfo>> updateMyInfo(
+            @Parameter(description = "사용자 이메일", example = "student@university.ac.kr", required = true)
             @RequestParam String email,
             @Valid @RequestBody UserRequestDto.UpdateRequest request) {
 
@@ -73,9 +154,30 @@ public class UserController {
      * 학과 인증 API (OCR 로직은 나중에 구현)
      * POST /api/users/verify-department
      */
-    @PostMapping("/verify-department/ocr")
+    @Operation(
+            summary = "학생증 OCR 인증",
+            description = "학생증 이미지를 OCR로 분석하여 학과를 인증합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "학과 인증 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponseDto.UserInfo.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (이미지 오류)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자 없음"
+            )
+    })
+    @PostMapping(value = "/verify-department/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<UserResponseDto.UserInfo>> verifyDepartmentWithOcr(
+            @Parameter(description = "사용자 이메일", example = "student@university.ac.kr", required = true)
             @RequestParam("email") String email,
+            @Parameter(description = "학생증 이미지 파일", required = true)
             @RequestParam("studentIdCard") MultipartFile studentIdCard) {
 
         try {

--- a/src/main/java/com/campus/campuscommunity/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/campus/campuscommunity/domain/user/dto/UserRequestDto.java
@@ -1,5 +1,6 @@
 package com.campus.campuscommunity.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -16,21 +17,26 @@ public class UserRequestDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "회원가입 요청 DTO")
     public static class SignUpRequest {
 
+        @Schema(description = "사용자 이메일", example = "user@university.ac.kr", required = true)
         @NotBlank(message = "이메일은 필수 입력값입니다.")
         @Email(message = "유효한 이메일 형식이 아닙니다.")
         private String email;
 
+        @Schema(description = "비밀번호 (8자 이상, 영문자+숫자 조합)", example = "password123", required = true)
         @NotBlank(message = "비밀번호는 필수 입력값입니다.")
         @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$",
                 message = "비밀번호는 영문자와 숫자를 포함해야 합니다.")
         private String password;
 
+        @Schema(description = "사용자 이름", example = "홍길동", required = true)
         @NotBlank(message = "이름은 필수 입력값입니다.")
         private String name;
 
+        @Schema(description = "학과명", example = "컴퓨터공학과", required = true)
         @NotBlank(message = "학과는 필수 입력값입니다.")
         private String department;
     }
@@ -39,12 +45,15 @@ public class UserRequestDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "로그인 요청 DTO")
     public static class LoginRequest {
 
+        @Schema(description = "사용자 이메일", example = "user@university.ac.kr", required = true)
         @NotBlank(message = "이메일은 필수 입력값입니다.")
         @Email(message = "유효한 이메일 형식이 아닙니다.")
         private String email;
 
+        @Schema(description = "비밀번호", example = "password123", required = true)
         @NotBlank(message = "비밀번호는 필수 입력값입니다.")
         private String password;
     }
@@ -53,11 +62,14 @@ public class UserRequestDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "회원 정보 수정 요청 DTO")
     public static class UpdateRequest {
 
+        @Schema(description = "변경할 이름", example = "김철수", required = true)
         @NotBlank(message = "이름은 필수 입력값입니다.")
         private String name;
 
+        @Schema(description = "변경할 학과명", example = "전자공학과", required = true)
         @NotBlank(message = "학과는 필수 입력값입니다.")
         private String department;
     }
@@ -66,11 +78,14 @@ public class UserRequestDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "비밀번호 변경 요청 DTO")
     public static class PasswordChangeRequest {
 
+        @Schema(description = "현재 비밀번호", example = "oldpassword123", required = true)
         @NotBlank(message = "현재 비밀번호는 필수 입력값입니다.")
         private String currentPassword;
 
+        @Schema(description = "새 비밀번호 (8자 이상, 영문자+숫자 조합)", example = "newpassword456", required = true)
         @NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
         @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$",

--- a/src/main/java/com/campus/campuscommunity/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/campus/campuscommunity/domain/user/dto/UserResponseDto.java
@@ -1,6 +1,7 @@
 package com.campus.campuscommunity.domain.user.dto;
 
 import com.campus.campuscommunity.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,11 +15,22 @@ public class UserResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "사용자 정보 응답 DTO")
     public static class UserInfo {
+
+        @Schema(description = "사용자 ID", example = "1")
         private Long id;
+
+        @Schema(description = "사용자 이메일", example = "user@university.ac.kr")
         private String email;
+
+        @Schema(description = "사용자 이름", example = "홍길동")
         private String name;
+
+        @Schema(description = "학과명", example = "컴퓨터공학과")
         private String department;
+
+        @Schema(description = "학과 인증 여부", example = "true")
         private boolean verified;
 
         // User 엔티티로부터 UserInfo DTO 생성하는 정적 메서드
@@ -38,8 +50,12 @@ public class UserResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "로그인 응답 DTO")
     public static class LoginResponse {
-        private String token;  // JWT 토큰
-        private UserInfo userInfo;  // 사용자 정보
+        @Schema(description = "JWT 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyQHVuaXZlcnNpdHkuYWMua3IiLCJpYXQiOjE2MTYxMjM4MDB9.example_token_signature")
+        private String token;
+
+        @Schema(description = "사용자 정보")
+        private UserInfo userInfo;
     }
 }


### PR DESCRIPTION
- 유저 관련 DTO(UserRequestDto, UserResponseDto)에 Swagger 어노테이션 추가
- UserController에 API 문서화를 위한 Swagger 어노테이션 추가
- 각 API 엔드포인트의 명확한 설명과 응답 코드 문서화
- 모든 요청/응답 필드에 대한 예제 값 추가
- 프론트엔드 개발자가 API를 쉽게 이해하고 사용할 수 있도록 개선